### PR TITLE
feat: support for projects who are mixing ts and js between a src and output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Development
+.idea
+
 # Environment
 *.env
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - windows
-  - linux
 language: node_js
 cache: npm
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-os:
-  - windows
-  - linux
-language: node_js
-cache: npm
-node_js:
-  - "10"  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+os:
+  - windows
+  - linux
+language: node_js
+node_js:
+  - "10"  

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ os:
   - windows
   - linux
 language: node_js
+cache: npm
 node_js:
   - "10"  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os:
   - windows
+  - linux
 language: node_js
 cache: npm
 node_js:

--- a/spec/fixtures/actual/dir/legacy.js
+++ b/spec/fixtures/actual/dir/legacy.js
@@ -1,0 +1,1 @@
+module.exports = 'foobar';

--- a/spec/fixtures/actual/dir/legacy.ts
+++ b/spec/fixtures/actual/dir/legacy.ts
@@ -1,0 +1,7 @@
+import legacy from './legacy';
+import * as legacy2 from './legacy.js';
+import constFile from './const-file.ts';
+
+export function legacy() {
+  return {legacy, legacy2, constFile};
+}

--- a/spec/fixtures/actual/main.ts
+++ b/spec/fixtures/actual/main.ts
@@ -1,3 +1,4 @@
+import { legacy as legacyFile } from "@dir/legacy";
 import { constFile as dirConstFile } from "@dir/const-file";
 import { constIndex as dirConstIndex } from "@dir/const-index";
 import { module1 as dirModule1 } from "@dir/module-file";
@@ -7,6 +8,7 @@ import { constIndex as subdirConstIndex } from "@dir/subdir/const-index";
 import { module1 as subdirModule1 } from "@dir/subdir/module-file";
 import { module2 as subdirModule2 } from "@dir/subdir/module-index";
 
+legacyFile();
 dirConstFile();
 dirConstIndex();
 dirModule1();

--- a/spec/fixtures/expect/dir/legacy.js
+++ b/spec/fixtures/expect/dir/legacy.js
@@ -1,0 +1,6 @@
+import legacy from "../../../actual/dir/legacy.js";
+import * as legacy2 from "../../../actual/dir/legacy.js";
+import constFile from "./const-file.ts";
+export function legacy() {
+    return { legacy, legacy2, constFile };
+}

--- a/spec/fixtures/expect/main.js
+++ b/spec/fixtures/expect/main.js
@@ -1,3 +1,4 @@
+import { legacy as legacyFile } from "./dir/legacy";
 import { constFile as dirConstFile } from "./dir/const-file";
 import { constIndex as dirConstIndex } from "./dir/const-index";
 import { module1 as dirModule1 } from "./dir/module-file";
@@ -6,6 +7,7 @@ import { constFile as subdirConstFile } from "./dir/subdir/const-file";
 import { constIndex as subdirConstIndex } from "./dir/subdir/const-index";
 import { module1 as subdirModule1 } from "./dir/subdir/module-file";
 import { module2 as subdirModule2 } from "./dir/subdir/module-index";
+legacyFile();
 dirConstFile();
 dirConstIndex();
 dirModule1();

--- a/spec/src/main.spec.ts
+++ b/spec/src/main.spec.ts
@@ -24,6 +24,10 @@ describe("paths", () => {
 });
 
 describe("dir-paths", () => {
+  it("legacy", async () => {
+    await assertFilesEqual("dir/legacy.js");
+  });
+
   it("const-file", async () => {
     await assertFilesEqual("dir/const-file.js");
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export class PathAliasResolver {
     } else {
       if (this.srcPath != this.outPath && requestedModule[0] == ".") {
         const normalizedFileName = path.normalize(fileName);
-        
+
         let relativeModulePath = normalizedFileName.replace(this.srcPath, "");
 
         let lookupFile = requestedModule;
@@ -97,16 +97,14 @@ export class PathAliasResolver {
           lookupFile
         );
 
-        console.log(requestedModule, relativeSrcModulePath);
-
         if (fs.existsSync(relativeSrcModulePath)) {
           // if a JS file exists in path within src directory, assume it will not be transpiled
-          return path
+          return path.posix.normalize(path
             .relative(
               normalizedFileName.replace(this.srcPath, this.outPath),
               relativeSrcModulePath
             )
-            .replace(/^\.\.\//g, "");
+            .replace(/^\.\.\//g, ""));
         }
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,8 @@ export class PathAliasResolver {
           lookupFile
         );
 
+        console.log(requestedModule, relativeSrcModulePath);
+
         if (fs.existsSync(relativeSrcModulePath)) {
           // if a JS file exists in path within src directory, assume it will not be transpiled
           return path

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export class PathAliasResolver {
   public resolve(fileName: string, requestedModule: string) {
     const mapping = this.options.getMapping(requestedModule);
     if (mapping) {
-      const absoluteJsRequire = path.join(this.outPath, mapping);
+      const absoluteJsRequire = path.join(this.srcPath, mapping);
       const sourceDir = path.dirname(fileName);
 
       let relativePath = path.relative(sourceDir, absoluteJsRequire);
@@ -83,7 +83,13 @@ export class PathAliasResolver {
       if(this.srcPath != this.outPath && requestedModule[0] == "."){
         let relativeModulePath = fileName.replace(this.srcPath, '');
 
-        const relativeSrcModulePath = path.join(this.srcPath, path.dirname(relativeModulePath), `${requestedModule}.js`);
+        let lookupFile = requestedModule;
+
+        if(!lookupFile.endsWith('.js')){
+          lookupFile = `${requestedModule}.js`;
+        }
+
+        const relativeSrcModulePath = path.join(this.srcPath, path.dirname(relativeModulePath), lookupFile);
 
         if(fs.existsSync(relativeSrcModulePath)){
           // if a JS file exists in path within src directory, assume it will not be transpiled

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,8 +59,8 @@ export class PathAliasResolver {
     const projectPath = process.cwd();
 
     this.options = new ProjectOptions(compilerOptions);
-    this.srcPath = path.resolve(projectPath, this.options.baseUrl || ".");
-    this.outPath = path.resolve(projectPath, this.options.outDir || ".");
+    this.srcPath = path.normalize(path.resolve(projectPath, this.options.baseUrl || "."));
+    this.outPath = path.normalize(path.resolve(projectPath, this.options.outDir || "."));
   }
 
   public resolve(fileName: string, requestedModule: string) {
@@ -81,8 +81,9 @@ export class PathAliasResolver {
       return relativePath.replace(REGEXP_ALL_BACKSLASH, "/");
     } else {
       if (this.srcPath != this.outPath && requestedModule[0] == ".") {
-        console.log(fileName, this.srcPath);
-        let relativeModulePath = fileName.replace(this.srcPath, "");
+        const normalizedFileName = path.normalize(fileName);
+        
+        let relativeModulePath = normalizedFileName.replace(this.srcPath, "");
 
         let lookupFile = requestedModule;
 
@@ -102,7 +103,7 @@ export class PathAliasResolver {
           // if a JS file exists in path within src directory, assume it will not be transpiled
           return path
             .relative(
-              fileName.replace(this.srcPath, this.outPath),
+              normalizedFileName.replace(this.srcPath, this.outPath),
               relativeSrcModulePath
             )
             .replace(/^\.\.\//g, "");

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,8 +59,12 @@ export class PathAliasResolver {
     const projectPath = process.cwd();
 
     this.options = new ProjectOptions(compilerOptions);
-    this.srcPath = path.normalize(path.resolve(projectPath, this.options.baseUrl || "."));
-    this.outPath = path.normalize(path.resolve(projectPath, this.options.outDir || "."));
+    this.srcPath = path.normalize(
+      path.resolve(projectPath, this.options.baseUrl || ".")
+    );
+    this.outPath = path.normalize(
+      path.resolve(projectPath, this.options.outDir || ".")
+    );
   }
 
   public resolve(fileName: string, requestedModule: string) {
@@ -99,12 +103,13 @@ export class PathAliasResolver {
 
         if (fs.existsSync(relativeSrcModulePath)) {
           // if a JS file exists in path within src directory, assume it will not be transpiled
-          return path.posix.normalize(path
+          return path
             .relative(
               normalizedFileName.replace(this.srcPath, this.outPath),
               relativeSrcModulePath
             )
-            .replace(/^\.\.\//g, ""));
+            .replace(/\\/g, "/") // force win32 paths to be POSIX
+            .replace(/^\.\.\//g, "");
         }
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,7 @@ export class PathAliasResolver {
         relativePath = "." + path.sep + relativePath;
       }
 
-      return relativePath.replace(REGEXP_ALL_BACKSLASH, "/"); //;
+      return relativePath.replace(REGEXP_ALL_BACKSLASH, "/");
     } else {
       if(this.srcPath != this.outPath && requestedModule[0] == "."){
         let relativeModulePath = fileName.replace(this.srcPath, '');

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export class PathAliasResolver {
       return relativePath.replace(REGEXP_ALL_BACKSLASH, "/");
     } else {
       if (this.srcPath != this.outPath && requestedModule[0] == ".") {
+        console.log(fileName, this.srcPath);
         let relativeModulePath = fileName.replace(this.srcPath, "");
 
         let lookupFile = requestedModule;

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,7 @@ export class PathAliasResolver {
               normalizedFileName.replace(this.srcPath, this.outPath),
               relativeSrcModulePath
             )
-            .replace(/\\/g, "/") // force win32 paths to be POSIX
+            .replace(REGEXP_ALL_BACKSLASH, "/") // force win32 paths to be POSIX
             .replace(/^\.\.\//g, "");
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,20 +80,29 @@ export class PathAliasResolver {
 
       return relativePath.replace(REGEXP_ALL_BACKSLASH, "/");
     } else {
-      if(this.srcPath != this.outPath && requestedModule[0] == "."){
-        let relativeModulePath = fileName.replace(this.srcPath, '');
+      if (this.srcPath != this.outPath && requestedModule[0] == ".") {
+        let relativeModulePath = fileName.replace(this.srcPath, "");
 
         let lookupFile = requestedModule;
 
-        if(!lookupFile.endsWith('.js')){
+        if (!lookupFile.endsWith(".js")) {
           lookupFile = `${requestedModule}.js`;
         }
 
-        const relativeSrcModulePath = path.join(this.srcPath, path.dirname(relativeModulePath), lookupFile);
+        const relativeSrcModulePath = path.join(
+          this.srcPath,
+          path.dirname(relativeModulePath),
+          lookupFile
+        );
 
-        if(fs.existsSync(relativeSrcModulePath)){
+        if (fs.existsSync(relativeSrcModulePath)) {
           // if a JS file exists in path within src directory, assume it will not be transpiled
-          return path.relative(fileName.replace(this.srcPath, this.outPath), relativeSrcModulePath).replace(/^\.\.\//g,'');
+          return path
+            .relative(
+              fileName.replace(this.srcPath, this.outPath),
+              relativeSrcModulePath
+            )
+            .replace(/^\.\.\//g, "");
         }
       }
 


### PR DESCRIPTION
i am in the process of converting legacy JS code to TS, and am using a lib/ for output to avoid having to commit compiled code into the repo (among other things).

if my TS code refers to old JS code (which lives in src/, not lib/), there are runtime issues. this change will detect if an original JS file exists at the module path, and if so, will rewrite the include to be relative to src (instead of assuming JS file is relative to TS file)