### PR TITLE
fix: only include dist/ in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "typings": "dist/index.d.ts",
   "license": "MIT",
   "author": "Igor Kuritsin <mail@onive.ru>",
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "test": "cross-env NODE_NO_WARNINGS=1 jasmine-ts \"spec/src/**/*.spec.ts\"",
     "prettier": "prettier --write \"src/**/*.{js,ts}\" \"spec/src/**/*.ts\" \"spec/fixtures/actual/**/*.{js,ts}\"",


### PR DESCRIPTION
When exploring an error I was getting when using this transformer with `ts-jest`, I noticed that the published package includes the entire repo, including both `spec` & `src` 😬 

I've added the `files` property to the `package.json` with just `dist/` so that only the contents of that folder (along with the `package.json`, `README` and `LICENSE` files) are packed when publishing :)