### PR TITLE
support non-wildcard aliases

### DIFF
--- a/src/alias-resolver.ts
+++ b/src/alias-resolver.ts
@@ -28,7 +28,7 @@ class ProjectOptions {
 
     const index = this.aliases.indexOf(alias);
     if (index < 0) {
-      return null;
+      return this.paths[this.aliases.indexOf(requestedModule)];
     }
 
     let mapping = this.paths[index];


### PR DESCRIPTION
support tsconfig paths that don't use the wildcard (`*`)

for example:

### index.ts:
```ts
import foo from '@foo/bar'
```
### tsconfig.json:
```json
{
    "paths": {
        "@foo/bar": "./foo/bar/baz"
    }
}
```

this previously failed because it was assuming all the paths used wildcards