### PR TITLE
fix: `ImportTypeNode` not mapped in `*.d.ts` files

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -55,7 +55,7 @@ export function transformerFactory<T extends TransformerNode>(
 
       /**
        * e.g.
-       * - import('path').Type;
+       * - type Foo = import('path').Foo;
        */
       if (ts.isImportTypeNode(node)) {
         return ts.visitEachChild(node, pathReplacer, context);

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -55,6 +55,14 @@ export function transformerFactory<T extends TransformerNode>(
 
       /**
        * e.g.
+       * - import('path').Type;
+       */
+      if (ts.isImportTypeNode(node)) {
+        return ts.visitEachChild(node, pathReplacer, context);
+      }
+
+      /**
+       * e.g.
        * - import * as x from 'path';
        * - import { x } from 'path';
        */


### PR DESCRIPTION
When importing types, TypeScript will (sometimes?) compile them to `import(...).Type` calls, which are [nodes of the type `ImportTypeNode`](https://ts-ast-viewer.com/#code/JYWwDg9gTgLgBAbzgMQhOBfOAzKERwBEAdAPTZqEBQVMAnmAKYppwC8coksAFIQH7lKASmKoIVIA). Currently, `ts-transform-paths` does not detect those nodes. This PR fixes that.

### Behavior before merging this PR

In order to reproduce:

1. Download and extract [reproduction.zip](https://github.com/OniVe/ts-transform-paths/files/6765457/reproduction.zip)
2. `npm install`
3. `npm run build`

`dist/bar/index.d.ts`:

``` ts
export declare function bar(_arg?: import("~/foo").Foo): void;
```

### Behavior after merging this PR

`dist/bar/index.d.ts`:

``` ts
export declare function bar(_arg?: import("../foo").Foo): void;
```

I'm not sure how to add a unit test, maybe you can help? I've also attached a small reproduction.